### PR TITLE
Fix crash.

### DIFF
--- a/src/fileio.py
+++ b/src/fileio.py
@@ -68,7 +68,7 @@ def write_out_estimate(F, depth, out_prefix):
 def write_matrix(matrix,name, stream):
     stream.write(u"> " + name + "\n")
     
-    if matrix == None:
+    if matrix is None:
         stream.write(str((0,0))+u"\n")
     else:
         stream.write(str(matrix.shape)+u"\n")


### PR DESCRIPTION
Using Python 2.7.15 on Arch Linux, PASTRI crashes with the following error:

```
Traceback (most recent call last):                                
  File "/home/micand/.apps/pastri/src/RunPASTRI.py", line 264, in <module>                                                           
    main()                                                        
  File "/home/micand/.apps/pastri/src/RunPASTRI.py", line 251, in main                                                               
    write_matrix(tree, str(i)+":"+str(index)+":"+str(-ll), out)   
  File "/home/micand/.apps/pastri/src/fileio.py", line 71, in write_matrix                                                           
    if matrix == None:                                            
ValueError: The truth value of an array with more than one element
is ambiguous. Use a.any() or a.all() 
```

Changing the `None` comparison as in this pull request fixes this.